### PR TITLE
Fix qa practice app link

### DIFF
--- a/links/testautomation.md
+++ b/links/testautomation.md
@@ -84,7 +84,7 @@ Getting Started with Maven in Less Than 10 Minutes – [Part 1](https://blog.tes
 [Playground Epizy](http://playground.epizy.com/)  
 [Practice Sofware Testing](practicesoftwaretesting.com)  
 [Public APIs (API)](https://github.com/public-apis/public-apis/blob/master/README.md)  
-[QA Automation Practice (WEB UI & API)](https://qa-practice.netlify.app/)  
+[QA Practice Elements (WEB UI & API)](https://qa-practice.netlify.app/)  
 [QA Playground](https://qaplayground.dev/)  
 [React Shopping Cart](https://react-shopping-cart-67954.firebaseapp.com/)  
 [RealWorld example apps (Web UI)](https://codebase.show/projects/realworld)  

--- a/links/testautomation.md
+++ b/links/testautomation.md
@@ -84,7 +84,7 @@ Getting Started with Maven in Less Than 10 Minutes – [Part 1](https://blog.tes
 [Playground Epizy](http://playground.epizy.com/)  
 [Practice Sofware Testing](practicesoftwaretesting.com)  
 [Public APIs (API)](https://github.com/public-apis/public-apis/blob/master/README.md)  
-[QA Automation Practice](https://qa-practice.netlify.app/)  
+[QA Automation Practice (WEB UI & API)](https://qa-practice.netlify.app/)  
 [QA Playground](https://qaplayground.dev/)  
 [React Shopping Cart](https://react-shopping-cart-67954.firebaseapp.com/)  
 [RealWorld example apps (Web UI)](https://codebase.show/projects/realworld)  

--- a/links/testautomation.md
+++ b/links/testautomation.md
@@ -83,7 +83,7 @@ Getting Started with Maven in Less Than 10 Minutes – [Part 1](https://blog.tes
 [ParaBank (Web UI & API)](https://parabank.parasoft.com/parabank/index.htm)  
 [Playground Epizy](http://playground.epizy.com/)  
 [Practice Sofware Testing](practicesoftwaretesting.com)  
-[Public APIs (API)](https://github.com/public-apis/public-apis/blob/master/README.md)
+[Public APIs (API)](https://github.com/public-apis/public-apis/blob/master/README.md)  
 [QA Automation Practice](https://qa-practice.netlify.app/)  
 [QA Playground](https://qaplayground.dev/)  
 [React Shopping Cart](https://react-shopping-cart-67954.firebaseapp.com/)  


### PR DESCRIPTION
There were 2 apps listed on the same line and I fixed them to be on separate lines in the list. I also renamed the QA Practice app to be more self explanatory.